### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubVis`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/R/scatter_plot_utils.R
+++ b/R/scatter_plot_utils.R
@@ -308,7 +308,7 @@ static_proj_data <- function(plot_model, df_point, df_ribbon,
 #' without target data.
 #' Simple projection model output are defined as projection associated with one
 #' particular set of "tasks_ids" value. For more information, please refer to
-#' [HubDocs website](https://hubverse.io/en/latest/user-guide/tasks.html)
+#' [HubDocs website](https://docs.hubverse.io/en/latest/user-guide/tasks.html)
 #' .
 #'
 #' @param plot_model a plot_ly object to add lines and/or ribbons.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal of hubVis is to provide plotting methods for hub model outputs,
 following the hubverse format. The hubverse is a collection of open-source
 software and data tools, developed by the Consortium of Infectious Disease
 Modeling Hubs. For more information, please consult the
-[hubDocs](https://hubverse.io/en/latest/) website
+[hubDocs](https://docs.hubverse.io/en/latest/) website
 
 ## Installation
 
@@ -87,6 +87,6 @@ Please note that the hubVis package is released with a [Contributor Code of Cond
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubVis package](.github/CONTRIBUTING.md).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubVis package](.github/CONTRIBUTING.md).
 
 

--- a/vignettes/plot_projection.Rmd
+++ b/vignettes/plot_projection.Rmd
@@ -30,7 +30,7 @@ Currently, the function can plot only quantile data, with the possibility to
 add "median" information from the model projections.
 
 For more information about the Hubverse standard format, please refer to the
-[HubDocs website](https://hubverse.io/en/latest/user-guide/tasks.html).
+[HubDocs website](https://docs.hubverse.io/en/latest/user-guide/tasks.html).
 
 The following vignette describes the principal usage of the
 `plot_step_ahead_model_output()` function.


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.