### PR TITLE
Fix gh-pages deploy (env.isPush → env.PUBLISH)

### DIFF
--- a/.github/workflows/pkgdown-netlify-preview.yaml
+++ b/.github/workflows/pkgdown-netlify-preview.yaml
@@ -53,7 +53,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy production to GitHub pages 🚀
-        if: contains(env.isPush, 'true')
+        if: contains(env.PUBLISH, 'true')
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f #v4.8.0
         with:
           clean: false


### PR DESCRIPTION
The **Deploy production to GitHub pages** step in `pkgdown-netlify-preview.yaml` is gated on `env.isPush`, but that variable is never defined — the workflow sets `PUBLISH`. So the condition is always false and the production gh-pages deploy has been silently skipped (gh-pages last updated 2025-03-28, even though the workflow reports success).

This points the condition at `env.PUBLISH` (matching the working config in sibling repos like hubCI), so pushes to `main` and releases deploy the docs again. As a side effect this also publishes the recently-merged Plausible snippet, which was stuck for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)